### PR TITLE
Lower minimum Neo4j version to 2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,15 @@
+sudo: false
 language: java
-jdk: oraclejdk7
+jdk:
+ - oraclejdk7
+ - oraclejdk8
+env:
+  matrix:
+    - NEO_VERSION=2.0.5
+    - NEO_VERSION=2.1.8
+    - NEO_VERSION=2.2.10
+      EXTRA_PROFILES=-Pwith-neo4j-io
+    - NEO_VERSION=2.3.5
+      EXTRA_PROFILES=-Pwith-neo4j-io
+install: true
+script: mvn clean test -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,13 @@
     <url>http://github.com/neo4j-contrib/neo4j-jdbc</url>
 
     <properties>
-        <neo4j.version>2.3.2</neo4j.version>
+        <encoding>UTF-8</encoding>
+        <java.version>1.7</java.version>
+        <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <neo4j.version>2.0.5</neo4j.version>
         <bundle.namespace>org.neo4j.jdbc</bundle.namespace>
         <short-name>neo4j-jdbc</short-name>
     </properties>
@@ -94,21 +100,6 @@
             <type>test-jar</type>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-io</artifactId>
-            <version>${neo4j.version}</version>
-            <type>test-jar</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j.app</groupId>
-            <artifactId>neo4j-server</artifactId>
-            <version>${neo4j.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
 
         <!-- Testing -->
         <dependency>
@@ -124,60 +115,38 @@
             <scope>test</scope>
         </dependency>
         <dependency>
- 	      <groupId>org.neo4j.app</groupId>
- 	      <artifactId>neo4j-server</artifactId>
- 	      <version>${neo4j.version}</version>
- 	      <exclusions>
- 	          <exclusion>
- 	              <groupId>org.neo4j</groupId>
- 	              <artifactId>neo4j</artifactId>
- 	          </exclusion>
- 	          <exclusion>
- 	              <groupId>ch.qos.logback</groupId>
- 	              <artifactId>logback-access</artifactId>
- 	          </exclusion>
- 	          <exclusion>
- 	              <groupId>ch.qos.logback</groupId>
- 	              <artifactId>logback-classic</artifactId>
- 	          </exclusion>
- 	          <exclusion>
- 	              <groupId>janino</groupId>
- 	              <artifactId>janino</artifactId>
- 	          </exclusion>
- 	          <exclusion>
- 	              <groupId>com.sun.jersey.contribs</groupId>
- 	              <artifactId>jersey-multipart</artifactId>
- 	          </exclusion>
- 	          <exclusion>
- 	              <groupId>bouncycastle</groupId>
- 	              <artifactId>bcprov-jdk16</artifactId>
- 	          </exclusion>
- 	      </exclusions>
- 	      <scope>test</scope>
- 	    </dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>${neo4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>${neo4j.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
+                <version>2.18.1</version>
                 <configuration>
-                    <argLine>-Xmx300m</argLine>
+                    <argLine>-Xmx1g</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-
+                <version>2.6</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -189,7 +158,6 @@
                         </manifest>
                     </archive>
                 </configuration>
-
                 <executions>
                     <execution>
                         <id>make-assembly</id>
@@ -255,14 +223,29 @@
         </plugins>
     </build>
 
-  <distributionManagement>
-    <repository>
-      <id>releases@repo.neo4j.org</id>
-      <name>releases@repo.neo4j.org</name>
-      <uniqueVersion>false</uniqueVersion>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
-    </repository>
-  </distributionManagement>
+    <profiles>
+        <profile>
+            <id>with-neo4j-io</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j-io</artifactId>
+                    <version>${neo4j.version}</version>
+                    <type>test-jar</type>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>releases@repo.neo4j.org</id>
+            <name>releases@repo.neo4j.org</name>
+            <uniqueVersion>false</uniqueVersion>
+            <url>http://m2.neo4j.org/content/repositories/releases</url>
+        </repository>
+    </distributionManagement>
 
 </project>
 

--- a/src/main/java/org/neo4j/jdbc/embedded/EmbeddedDatabases.java
+++ b/src/main/java/org/neo4j/jdbc/embedded/EmbeddedDatabases.java
@@ -18,13 +18,6 @@
  */
 package org.neo4j.jdbc.embedded;
 
-import java.io.File;
-import java.util.Map;
-import java.util.Properties;
-import java.util.WeakHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
@@ -32,6 +25,12 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.jdbc.Databases;
 import org.neo4j.jdbc.QueryExecutor;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.WeakHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author mh
@@ -65,7 +64,7 @@ public class EmbeddedDatabases implements Databases
                     GraphDatabaseBuilder builder = new GraphDatabaseBuilder(new GraphDatabaseBuilder.DatabaseCreator() {
                         @Override
                         public GraphDatabaseService newDatabase(Map<String, String> map) {
-                            return new GraphDatabaseFactory().newEmbeddedDatabase(new File(name));
+                            return new GraphDatabaseFactory().newEmbeddedDatabase(name);
                         }
                     });
 

--- a/src/test/java/org/neo4j/jdbc/FileVisitor.java
+++ b/src/test/java/org/neo4j/jdbc/FileVisitor.java
@@ -1,0 +1,34 @@
+package org.neo4j.jdbc;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+class FileVisitor extends SimpleFileVisitor<Path> {
+
+    private FileVisitor() {}
+
+    public static FileVisitor deleteRecursively() {
+        return new FileVisitor();
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/src/test/java/org/neo4j/jdbc/GraphDatabaseIntrospector.java
+++ b/src/test/java/org/neo4j/jdbc/GraphDatabaseIntrospector.java
@@ -1,0 +1,19 @@
+package org.neo4j.jdbc;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.EmbeddedGraphDatabase;
+
+class GraphDatabaseIntrospector {
+
+    public static boolean isEmbedded(GraphDatabaseService db) {
+        return getEmbeddedClass().isAssignableFrom(db.getClass());
+    }
+
+    private static Class<?> getEmbeddedClass() {
+        try {
+            return Class.forName("org.neo4j.kernel.impl.factory.GraphDatabaseFacade");
+        } catch (ClassNotFoundException e) {
+            return EmbeddedGraphDatabase.class;
+        }
+    }
+}

--- a/src/test/java/org/neo4j/jdbc/Neo4jConnectionTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jConnectionTest.java
@@ -18,28 +18,28 @@
  */
 package org.neo4j.jdbc;
 
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.tooling.GlobalGraphOperations;
+
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.DynamicLabel;
-import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.tooling.GlobalGraphOperations;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.DynamicLabel.label;
 
 public class Neo4jConnectionTest extends Neo4jJdbcTest
 {
@@ -47,7 +47,6 @@ public class Neo4jConnectionTest extends Neo4jJdbcTest
     private String columName = "propName";
     private String tableName = "test";
     private String columnPrefix = "_";
-    private final String columnType = "String";
 
     public Neo4jConnectionTest( Mode mode ) throws SQLException
     {
@@ -70,7 +69,7 @@ public class Neo4jConnectionTest extends Neo4jJdbcTest
     public void setUp() throws Exception
     {
         super.setUp();
-        createTableMetaData( gdb, tableName, columName, columnType );
+        createTableMetaData( gdb, tableName, columName, "String");
     }
 
     @Test
@@ -78,8 +77,8 @@ public class Neo4jConnectionTest extends Neo4jJdbcTest
     {
         try ( Transaction tx = gdb.beginTx() )
         {
-            final Node root = IteratorUtil.single( gdb.findNodes( DynamicLabel
-                    .label( "MetaDataRoot" ) ) );
+            ResourceIterable<Node> nodes = GlobalGraphOperations.at(gdb).getAllNodesWithLabel(label("MetaDataRoot"));
+            final Node root = IteratorUtil.single(nodes);
             final Relationship typeRel = root.getSingleRelationship( DynamicRelationshipType.withName( "TYPE" ),
                     Direction.OUTGOING );
             final Node typeNode = typeRel.getEndNode();

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
 /**
@@ -101,9 +102,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         int count = 0;
         ps.executeUpdate();
         begin();
-        ResourceIterator<Node> nodes = gdb.findNodes( DynamicLabel.label( "User" ) );
-        while (nodes.hasNext()) {
-            assertEquals( "test", nodes.next().getProperty( "name" ) );
+        for (Node node : GlobalGraphOperations.at(gdb).getAllNodesWithLabel(label("User"))) {
+            assertEquals("test", node.getProperty("name"));
             count++;
         }
         done();
@@ -119,10 +119,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         int count = 0;
         ps.executeUpdate();
         begin();
-        ResourceIterator<Node> nodes = gdb.findNodes( DynamicLabel.label( "User" ) );
-        while (nodes.hasNext())
-        {
-            assertEquals( "test", nodes.next().getProperty( "name" ) );
+        for (Node node : GlobalGraphOperations.at(gdb).getAllNodesWithLabel(label("User"))) {
+            assertEquals("test", node.getProperty("name"));
             count++;
         }
         done();

--- a/src/test/java/org/neo4j/jdbc/TestServer.java
+++ b/src/test/java/org/neo4j/jdbc/TestServer.java
@@ -22,8 +22,6 @@ import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.web.WebServer;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 
 /**

--- a/src/test/java/org/neo4j/jdbc/embedded/CypherCreateTest.java
+++ b/src/test/java/org/neo4j/jdbc/embedded/CypherCreateTest.java
@@ -18,17 +18,16 @@
  */
 package org.neo4j.jdbc.embedded;
 
-import java.util.Collections;
-
 import org.junit.Test;
-
+import org.neo4j.cypher.javacompat.ExecutionEngine;
+import org.neo4j.cypher.javacompat.ExecutionResult;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,7 +41,8 @@ public class CypherCreateTest
     public void testCreateNodeWithParam() throws Exception
     {
         final GraphDatabaseService gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        Result result = gdb.execute( "create (n {name:{1}}) return id(n) as id", Collections.<String,
+        ExecutionEngine executionEngine = new ExecutionEngine(gdb);
+        ExecutionResult result = executionEngine.execute( "create (n {name:{1}}) return id(n) as id", Collections.<String,
                 Object>singletonMap( "1", "test" ) );
         Long id = IteratorUtil.single( result.<Long>columnAs( "id" ) );
         try ( Transaction tx = gdb.beginTx() )


### PR DESCRIPTION
This allows users to benefit from all the latest fixes done in
later driver versions while using an older 2.x Neo4j version.

This also makes sure the JDBC driver builds against all latest
Neo4j 2.x branches (i.e. 2.0.x, 2.1.x, 2.2.x, 2.3.x).

Because of the minimum Neo4j version change, the project version
has also been changed to 2.0.5-SNAPSHOT to reflect this.
